### PR TITLE
[vietocr] tool translate resize Image.LANCZOS

### DIFF
--- a/vietocr/tool/translate.py
+++ b/vietocr/tool/translate.py
@@ -146,7 +146,7 @@ def process_image(image, image_height, image_min_width, image_max_width):
     w, h = img.size
     new_w, image_height = resize(w, h, image_height, image_min_width, image_max_width)
 
-    img = img.resize((new_w, image_height), Image.ANTIALIAS)
+    img = img.resize((new_w, image_height), Image.LANCZOS)
 
     img = np.asarray(img).transpose(2,0, 1)
     img = img/255


### PR DESCRIPTION
... /site-packages/vietocr/tool/translate.py:149: DeprecationWarning: ANTIALIAS is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.LANCZOS instead.
  img = img.resize((new_w, image_height), Image.ANTIALIAS)